### PR TITLE
Catch resource existance exceptions when resource isn't found

### DIFF
--- a/ckanext/solr_heatmap/lib.py
+++ b/ckanext/solr_heatmap/lib.py
@@ -15,5 +15,12 @@ def get_datastore_geospatial_fields(resource_id, context):
     @return:
     """
     data = {'resource_id': resource_id, 'limit': 0}
-    fields = toolkit.get_action('datastore_search')(context, data)['fields']
-    return sorted([f['id'] for f in fields if f['type'] == 'geospatial_rpt'])
+    try:
+        fields = toolkit.get_action('datastore_search')(context, data)['fields']
+    except toolkit.ObjectNotFound:
+        # if the resource isn't found in the solr datastore (or indeed the
+        # standard datastore which the solr datastore action passes off to)
+        # that's fine, but we should catch the error
+        return []
+    else:
+        return sorted([f['id'] for f in fields if f['type'] == 'geospatial_rpt'])


### PR DESCRIPTION
If the resource doesn't exist in the solr datastore when we're looking for solr datastore related information we should return an empty list of geospatial fields not raise an exception. The exception itself comes from the datastore search action, not the solr one, because if the resource isn't in the solr datastore then we ignore it and pass the action on to the standard datastore itself.